### PR TITLE
Do not delete the repo's default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A GitHub action to automatically delete the branch after a pull request has been merged. 
 
-> **NOTE:** This will **never** delete a branch named "master". If the pull request is closed _without_ merging, it will **not** delete it.
+> **NOTE:** This will **never** delete the repository's default branch. If the pull request is closed _without_ merging, it will **not** delete it.
 
 
 ```

--- a/cleanup-pr-branch
+++ b/cleanup-pr-branch
@@ -32,10 +32,16 @@ main(){
 		ref=$(jq --raw-output .pull_request.head.ref "$GITHUB_EVENT_PATH")
 		owner=$(jq --raw-output .pull_request.head.repo.owner.login "$GITHUB_EVENT_PATH")
 		repo=$(jq --raw-output .pull_request.head.repo.name "$GITHUB_EVENT_PATH")
+		default_branch=$(
+ 			curl -XGET -sSL \
+				-H "${AUTH_HEADER}" \
+ 				-H "${API_HEADER}" \
+				"${URI}/repos/${owner}/${repo}" | jq .default_branch
+		)
 
-		if [[ "$ref" == "master" ]]; then
-			# Never delete the master branch.
-			echo "Will not delete master branch for ${owner}/${repo}, exiting."
+		if [[ "$ref" == "$default_branch" ]]; then
+			# Never delete the default branch.
+			echo "Will not delete default branch (${default_branch}) for ${owner}/${repo}, exiting."
 			exit 0
 		fi
 


### PR DESCRIPTION
This action is extremely handy, thank you!

The master branch isn't necessarily the repo's default branch. I made a change to check for the default branch instead but maybe the right thing to do is refuse to delete master _and_ the default?