### PR TITLE
Mark workflow run green after deletion

### DIFF
--- a/cleanup-pr-branch
+++ b/cleanup-pr-branch
@@ -52,6 +52,7 @@ main(){
 			"${URI}/repos/${owner}/${repo}/git/refs/heads/${ref}"
 
 		echo "Branch delete success!"
+		exit 0
 	fi
 	exit 78
 }


### PR DESCRIPTION
When actually deleting a branch, I think it makes sense to mark the run green. I see that this was changed in https://github.com/jessfraz/branch-cleanup-action/pull/8 and my guess is that this case was just missed.