### PR TITLE
Let action fail when GitHub API request fails

### DIFF
--- a/cleanup-pr-branch
+++ b/cleanup-pr-branch
@@ -33,7 +33,7 @@ main(){
 		owner=$(jq --raw-output .pull_request.head.repo.owner.login "$GITHUB_EVENT_PATH")
 		repo=$(jq --raw-output .pull_request.head.repo.name "$GITHUB_EVENT_PATH")
 		default_branch=$(
- 			curl -XGET -sSL \
+ 			curl -XGET -fsSL \
 				-H "${AUTH_HEADER}" \
  				-H "${API_HEADER}" \
 				"${URI}/repos/${owner}/${repo}" | jq .default_branch
@@ -46,7 +46,7 @@ main(){
 		fi
 
 		echo "Deleting branch ref $ref for owner ${owner}/${repo}..."
-		curl -XDELETE -sSL \
+		curl -XDELETE -fsSL \
 			-H "${AUTH_HEADER}" \
 			-H "${API_HEADER}" \
 			"${URI}/repos/${owner}/${repo}/git/refs/heads/${ref}"


### PR DESCRIPTION
In order to make the action fail when the requests to the GitHub API fail, this PR makes `curl` return with exit code 22 in cases of HTTP errors. 