### PR TITLE
[Trivial] Dockerfile Lint Tools & Official docs say MAINTAINER is deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-MAINTAINER Jessica Frazelle <jess@linux.com>
+LABEL maintainer="Jessica Frazelle <jess@linux.com>"
 
 LABEL "com.github.actions.name"="Branch Cleanup"
 LABEL "com.github.actions.description"="Delete the branch after a pull request has been merged"


### PR DESCRIPTION
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

Feel free to ignore this if it's an inappropriate change! I'm a newbie at Docker so I'm just doing what my tools tell me.