### PR TITLE
Removal of neutral status code

### DIFF
--- a/cleanup-pr-branch
+++ b/cleanup-pr-branch
@@ -16,11 +16,9 @@ API_VERSION=v3
 API_HEADER="Accept: application/vnd.github.${API_VERSION}+json"
 AUTH_HEADER="Authorization: token ${GITHUB_TOKEN}"
 
-# Github Actions will mark a check as "neutral" (neither failed/succeeded) when you exit with code 78
-# But this will terminate any other Actions running in parallel in the same workflow.
-# Configuring this Environment Variable `NO_BRANCH_DELETED_EXIT_CODE=0` if no branch was deleted will let your workflow continue.
-# Docs: https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#exit-codes-and-statuses
-NO_BRANCH_DELETED_EXIT_CODE=${NO_BRANCH_DELETED_EXIT_CODE:-78}
+# Github Actions uses either status code 0 for success or any other code for failure.
+# Docs: https://help.github.com/en/articles/virtual-environments-for-github-actions#exit-codes-and-statuses
+NO_BRANCH_DELETED_EXIT_CODE=${NO_BRANCH_DELETED_EXIT_CODE:-0}
 
 main(){
 	action=$(jq --raw-output .action "$GITHUB_EVENT_PATH")


### PR DESCRIPTION
With the change to YAML and the new CICD oriented actions, we lost the ability to use exit code 78.

This is switching to status code 0 to show success as oppose to a failure on a status check.

https://help.github.com/en/articles/virtual-environments-for-github-actions#exit-codes-and-statuses